### PR TITLE
Ensure flexget installs version 2.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### ⚠️⚠️ Last tested version of OSMC is [**2018.03-2**](https://osmc.tv/download/images/). Newer versions probably need tweaking
+### ⚠️⚠️ Last tested version of OSMC is [**2020.03-1**](https://osmc.tv/download/images/). Newer versions probably need tweaking
 
 Build status: [![Build Status](https://travis-ci.org/alombarte/raspberry-osmc-automated.svg?branch=master)](https://travis-ci.org/alombarte/raspberry-osmc-automated)
 

--- a/bash/install_flexget.sh
+++ b/bash/install_flexget.sh
@@ -15,7 +15,9 @@ CONFIG_RSS_FEED=$(echo "$3" | sed -e 's/[\/&]/\\&/g')
 sudo apt-get install python-pip python-setuptools --yes
 # six>=1.9.0 to run flex needed:
 sudo pip install six --upgrade
-sudo easy_install flexget
+# Only flexget 2.x.x is supported by Python 2.7
+sudo pip install --upgrade setuptools
+sudo pip install "flexget>=2.0,<3.0"
 
 # Add FlexGet configuration:
 mkdir -p ~/.flexget


### PR DESCRIPTION
Fixes #39 

Upgrade of setuptools is required to ensure successful install of flexget